### PR TITLE
Return 11067 ruby 3.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    image_server (0.9.0)
+    image_server (0.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/image_server/active_record.rb
+++ b/lib/image_server/active_record.rb
@@ -39,7 +39,7 @@ module ImageServer
                       format: '#{default_format}',
                       processing: #{column}_processing?,
                       object: self }
-          ImageServer::Image.new(#{namespace_constant}, #{column}_hash, default_options.merge(options))
+          ImageServer::Image.new(#{namespace_constant}, #{column}_hash, **default_options.merge(options))
         end
 
         def #{column}_url(*attrs)

--- a/lib/image_server/image.rb
+++ b/lib/image_server/image.rb
@@ -28,7 +28,7 @@ module ImageServer
         format: 'jpg',
       }.merge(options)
 
-      ImageServer::Url.from_hash(@namespace, @image_hash, options)
+      ImageServer::Url.from_hash(@namespace, @image_hash, **options)
     end
   end
 end

--- a/lib/image_server/version.rb
+++ b/lib/image_server/version.rb
@@ -1,3 +1,3 @@
 module ImageServer
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
<!-- Pull request guide https://returnly.atlassian.net/wiki/spaces/ENG/pages/2963439664/EngineCare+WebApps+Pull+Request+Best+Practices -->
# Ticket 🎫

:link: RETURN-11067

# Context 📓
Making ImageServer and ReturnlyCommon gems compatible with Ruby 3.0 

# Testing 🧪
https://buildkite.com/returnly/multiqa-deploy/builds/16145
https://buildkite.com/returnly/qa-test-automation-sanity-execution-multiqa/builds/4007

# Client applications PR's 📎

- https://github.com/returnly/returns-center/pull/3669
- https://github.com/returnly/dashboard/pull/3457
- https://github.com/returnly/ruby-returnly-common/pull/500

## Before merge

- [ ] :warning: Test them on dev before merging, merge them, deploy and validate just
after merging the gem.
